### PR TITLE
Update composer.json to require libxml

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,21 +1,24 @@
 {
-    "name": "electrolinux/phpquery"
-    ,"type": "library"
-    ,"description": "phpQuery is a server-side, chainable, CSS3 selector driven Document Object Model (DOM) API based on jQuery JavaScript Library"
-    ,"version": "0.9.6"
-    ,"keywords": []
-    ,"homepage": "http://code.google.com/p/phpquery/"
-    ,"license": "MIT"
-    ,"authors": [
+    "name": "electrolinux/phpquery",
+    "type": "library",
+    "description": "phpQuery is a server-side, chainable, CSS3 selector driven Document Object Model (DOM) API based on jQuery JavaScript Library",
+    "version": "0.9.6",
+    "keywords": [],
+    "homepage": "http://code.google.com/p/phpquery/",
+    "license": "MIT",
+    "require": {
+        "lib-libxml": "*",
+    },
+    "authors": [
         {
-            "name": "Tobiasz Cudnik"
-            ,"email": "tobiasz.cudnik@gmail.com"
-            ,"homepage": "https://github.com/TobiaszCudnik"
-            ,"role": "Developer"
-        }
-        ,{
-            "name": "didier Belot"
-            ,"role": "Packager"
+            "name": "Tobiasz Cudnik",
+            "email": "tobiasz.cudnik@gmail.com",
+            "homepage": "https://github.com/TobiaszCudnik",
+            "role": "Developer"
+        },
+        {
+            "name": "didier Belot",
+            "role": "Packager"
         }
     ],
     "autoload": {


### PR DESCRIPTION
In this pull request I've inserted the requirement for libxml necessary to fix the error:

PHP message: PHP Fatal error:  Uncaught Error: Class 'DOMDocument' not found in vendor/electrolinux/phpquery/phpQuery/phpQuery/DOMDocumentWrapper.php:128